### PR TITLE
fixes #9: add fixture test, validating everything.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   },
   "dependencies": {
     "esutils": "^1.1.6",
-    "shift-reducer": "^1.0.2"
+    "shift-reducer": "^1.0.3"
   },
   "devDependencies": {
     "6to5": "^1.14.14",
+    "everything.js": "0.0.4",
     "mocha": "^2.0.1",
-    "shift-ast": "^1.0.3"
+    "shift-ast": "^1.0.3",
+    "shift-parser": "^1.0.2"
   },
   "keywords": [
     "Shift",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2014 Shape Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "fs";
+import * as assert from "assert";
+
+import * as Shift from "shift-ast";
+import parse from "shift-parser";
+
+import isValid, {Validator} from "../";
+
+suite("fixtures", () => {
+  test("validator is valid", () => {
+    let source = "" + fs.readFileSync(require.resolve("../"));
+    let ast = parse(source);
+    assert(isValid(ast));
+  });
+
+  test("everything.js is valid", () => {
+    let source = "" + fs.readFileSync(require.resolve("everything.js"));
+    let ast = parse(source);
+    assert(isValid(ast));
+  });
+});


### PR DESCRIPTION
Fixes #9. This is not ready to be merged, as the parser is failing to create a valid AST. The validator is reporting a `LiteralNumericExpression` with an infinite `value`. This issue was reported as https://github.com/shapesecurity/shift-parser-js/issues/11.